### PR TITLE
Update licence in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ If you want to override default pure behavior use `--no-pure` flag.
 
 ## Licence
 
-WTF.
+[MIT](/LICENCE.md)


### PR DESCRIPTION
Readme lists the license as WTF even though `LICENCE.md` and `package.json` say MIT.

Alternatively, if you'd like to license under the [WTFPL](https://choosealicense.com/licenses/wtfpl/), I'd be happy to change `LICENCE.md` and `package.json` accordingly instead. 👌🏼