### PR TITLE
updated package removal code

### DIFF
--- a/src/remove.ts
+++ b/src/remove.ts
@@ -118,7 +118,7 @@ export const removePackages = async (
 
   const yalcFolder = join(workingDir, values.yalcPackagesFolder)
   removedPackagedFromManifest.forEach((name) => {
-    fs.removeSync(join(workingDir, 'node_modules', name))
+    fs.unlinkSync(join(workingDir, 'node_modules', name))
   })
   packagesToRemove.forEach((name) => {
     if (!options.retreat) {


### PR DESCRIPTION
Changed `fs.removeSync` to `fs.unlinkSync` as I believe that this line is for removing the symlink in the case of `pure`, however, this also removes the actual package from `node_modules` when using `yalc add` on a non-workspace project which is very unexpected behavior. Re: https://github.com/wclr/yalc/issues/38