### PR TITLE
feat(rc): add store folder to rc file

### DIFF
--- a/src/rc.ts
+++ b/src/rc.ts
@@ -8,6 +8,7 @@ const validFlags = [
   'scripts',
   'quiet',
   'files',
+  'store-folder'
 ]
 
 const fileName = '.yalcrc'


### PR DESCRIPTION
- feat: Adds store folder to rc file.


# Why?
Needed to add this to create a localized store for a multi-repo project across multiple docker containers.

Simplifies having to specify `--store-folder` on every command.