### PR TITLE
support YALC_STORE_PATH system environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If you want to override default pure behavior use `--no-pure` flag.
 ### Override default package store folder
 
 - You may use `--store-folder` flag option to override default location for storing published packages.
+- You may use `YALC_STORE_PATH` in system environment to override default location for storing published packages.
 
 ### Control output
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ExecSyncOptions } from 'child_process'
 import * as fs from 'fs-extra'
 import { homedir } from 'os'
-import { join } from 'path'
+import { join, resolve } from 'path'
 
 const userHome = homedir()
 
@@ -87,4 +87,9 @@ export const writeSignatureFile = (workingDir: string, signature: string) => {
     console.error('Could not write signature file')
     throw e
   }
+}
+
+if (process.env.YALC_STORE_PATH) {
+  yalcGlobal.yalcStoreMainDir = resolve(process.env.YALC_STORE_PATH)
+  console.log('Package store folder(in env) used:', yalcGlobal.yalcStoreMainDir)
 }


### PR DESCRIPTION
- support `YALC_STORE_PATH` system environment
  it's rank below than `--store-folder`