### PR TITLE
use version 0.0.1 as default

### DIFF
--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -59,13 +59,19 @@ export function readPackageManifest(workingDir: string) {
   try {
     const fileData = fs.readFileSync(packagePath, 'utf-8')
     pkg = JSON.parse(fileData) as PackageManifest
-    if (!pkg.name && pkg.version) {
+    if (!pkg.name) {
       console.log(
         'Package manifest',
         packagePath,
-        'should contain name and version.'
+        'should contain name'
       )
       return null
+    }
+    if (!pkg.version) {
+      console.log(
+        'No version found in package manifest, using 0.0.1'
+      )
+      pkg.version = '0.0.1'
     }
     const indent = getIndent(fileData) || '  '
     pkg.__Indent = indent


### PR DESCRIPTION
When no version is provided in package manifest (eg. project is using semantic release) use version `0.0.1` as default

Currently when I run `yalc publish` in project without version I get an error:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (internal/errors.js:322:7)
    at validateString (internal/validators.js:124:11)
    at Object.join (path.js:1148:7)
    at ~/.config/yarn/global/node_modules/yalc/src/copy.js:155:47
    at step (~/.config/yarn/global/node_modules/yalc/src/copy.js:44:23)
    at Object.next (~/.config/yarn/global/node_modules/yalc/src/copy.js:25:53)
    at ~/.config/yarn/global/node_modules/yalc/src/copy.js:19:71
    at new Promise (<anonymous>)
    at __awaiter (~/.config/yarn/global/node_modules/yalc/src/copy.js:15:12)
    at Object.exports.copyPackageToStore (~/.config/yarn/global/node_modules/yalc/src/copy.js:144:58) {
```