### PR TITLE
feat: add portal protocol option to yalc add

### DIFF
--- a/src/lockfile.ts
+++ b/src/lockfile.ts
@@ -14,6 +14,7 @@ export type LockFilePackageEntry = {
   version?: string
   file?: boolean
   link?: boolean
+  portal?: boolean
   replaced?: string
   signature?: string
   pure?: boolean
@@ -90,7 +91,7 @@ export const addPackageToLockfile = (
 ) => {
   const lockfile = readLockfile(options)
   packages.forEach(
-    ({ name, version, file, link, replaced, signature, pure, workspace }) => {
+    ({ name, version, file, link, portal, replaced, signature, pure, workspace }) => {
       let old = lockfile.packages[name] || {}
       lockfile.packages[name] = {}
       if (version) {
@@ -104,6 +105,9 @@ export const addPackageToLockfile = (
       }
       if (link) {
         lockfile.packages[name].link = true
+      }
+      if (portal) {
+        lockfile.packages[name].portal = true
       }
       if (pure) {
         lockfile.packages[name].pure = true

--- a/src/update.ts
+++ b/src/update.ts
@@ -48,6 +48,7 @@ export const updatePackages = async (
     file: lockfile.packages[name].file,
     link: lockfile.packages[name].link,
     pure: lockfile.packages[name].pure,
+    portal: lockfile.packages[name].portal,
     workspace: lockfile.packages[name].workspace,
   }))
 
@@ -68,7 +69,7 @@ export const updatePackages = async (
   })
 
   const packagesLinks = lockPackages
-    .filter((p) => !p.file && !p.link && !p.pure && !p.workspace)
+    .filter((p) => !p.file && !p.link && !p.portal && !p.pure && !p.workspace)
     .map((p) => p.name)
   await addPackages(packagesLinks, {
     ...addOpts,
@@ -80,6 +81,13 @@ export const updatePackages = async (
   await addPackages(packagesWks, {
     ...addOpts,
     workspace: true,
+    pure: false,
+  })
+
+  const packagesPortalDep = lockPackages.filter((p) => p.portal).map((p) => p.name)
+  await addPackages(packagesPortalDep, {
+    ...addOpts,
+    portalDep: true,
     pure: false,
   })
 

--- a/src/yalc.ts
+++ b/src/yalc.ts
@@ -154,7 +154,7 @@ yargs
     describe: 'Add package from yalc repo to the project',
     builder: () => {
       return yargs
-        .boolean(['file', 'dev', 'link', ...updateFlags])
+        .boolean(['file', 'dev', 'link', 'portal', ...updateFlags])
         .alias('D', 'dev')
         .boolean('workspace')
         .alias('save-dev', 'dev')
@@ -166,6 +166,7 @@ yargs
       return addPackages(argv._.slice(1), {
         dev: argv.dev,
         linkDep: argv.link,
+        portalDep: argv.portal,
         restore: argv.restore,
         pure: argv.pure,
         workspace: argv.workspace,

--- a/test/index.ts
+++ b/test/index.ts
@@ -514,4 +514,74 @@ describe('Yalc package manager', function () {
       })
     })
   })
+
+  describe('Add package (--portal)', () => {
+    before(() => {
+      return addPackages([values.depPackage], {
+        workingDir: projectDir,
+        portalDep: true,
+      })
+    })
+    it('copies package to .yalc folder', () => {
+      checkExists(join(projectDir, '.yalc', values.depPackage))
+    })
+    it('copies remove package to node_modules', () => {
+      checkExists(join(projectDir, 'node_modules', values.depPackage))
+    })
+    it('creates to yalc.lock', () => {
+      checkExists(join(projectDir, 'yalc.lock'))
+    })
+    it('places yalc.lock correct info about file', () => {
+      const lockFile = readLockfile({ workingDir: projectDir })
+      deepEqual(lockFile.packages, {
+        [values.depPackage]: {
+          portal: true,
+          replaced: 'link:.yalc/' + values.depPackage,
+          signature: extractSignature(lockFile, values.depPackage),
+        },
+      })
+    })
+    it('updates package.json', () => {
+      const pkg = readPackageManifest(projectDir)!
+      deepEqual(pkg.dependencies, {
+        [values.depPackage]: 'portal:.yalc/' + values.depPackage,
+      })
+    })
+    it('create and updates installations file', () => {
+      const installtions = readInstallationsFile()
+      deepEqual(installtions, {
+        [values.depPackage]: [projectDir],
+      })
+    })
+  })
+
+  describe('Updated linked (--portal) package', () => {
+    before(() => {
+      return updatePackages([values.depPackage], {
+        workingDir: projectDir,
+      })
+    })
+    it('places yalc.lock correct info about file', () => {
+      const lockFile = readLockfile({ workingDir: projectDir })
+      deepEqual(lockFile.packages, {
+        [values.depPackage]: {
+          portal: true,
+          replaced: 'link:.yalc/' + values.depPackage,
+          signature: extractSignature(lockFile, values.depPackage),
+        },
+      })
+    })
+    it('updates package.json', () => {
+      const pkg = readPackageManifest(projectDir)!
+      deepEqual(pkg.dependencies, {
+        [values.depPackage]: 'portal:.yalc/' + values.depPackage,
+      })
+    })
+    it('create and updates installations file', () => {
+      const installtions = readInstallationsFile()
+      deepEqual(installtions, {
+        [values.depPackage]: [projectDir],
+      })
+    })
+  })
 })


### PR DESCRIPTION
In new versions of Yarn, there is a new protocol that acts like `link:` but that follows dependencies of the linked package. 

Here is the list of the currently supported protocols: [Yarn Protocols ](https://yarnpkg.com/features/protocols)

This PR introduces a new option `--portal` to `yalc add` so that we can add a package to a repository with `portal:`. 

CC: @wclr 
