### PR TITLE
Adds reference to docs for workspace usage

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -148,12 +148,15 @@ export const addPackages = async (
           console.warn(
             'Because of `workspaces` enabled in this package ' + defaultPureMsg
           )
-          console.warn('Please see the workspaces docs to ensure your project is configured correctly https://github.com/wclr/yalc#use-with-yarnpnpm-workspaces.');
         } else if (pnpmWorkspace) {
           console.warn(
             'Because of `pnpm-workspace.yaml` exists in this package ' +
               defaultPureMsg
           )
+        }
+
+        if (localPkg.workspaces || pnpmWorkspace) {
+          console.warn('Please see the workspaces docs to ensure your project is configured correctly https://github.com/wclr/yalc#use-with-yarnpnpm-workspaces.');
         }
       }
       console.log(

--- a/src/add.ts
+++ b/src/add.ts
@@ -148,6 +148,7 @@ export const addPackages = async (
           console.warn(
             'Because of `workspaces` enabled in this package ' + defaultPureMsg
           )
+          console.warn('Please see the workspaces docs to ensure your project is configured correctly https://github.com/wclr/yalc#use-with-yarnpnpm-workspaces.');
         } else if (pnpmWorkspace) {
           console.warn(
             'Because of `pnpm-workspace.yaml` exists in this package ' +


### PR DESCRIPTION
Adds reference to documentation for workspace usage, since `yalc link` appears to have worked, however, it won't work until the yalc folder has been correctly added to the `workspace` definition. 

(Maybe we should consider automatically updating the workspaces instead?)

<img width="217" alt="image" src="https://github.com/wclr/yalc/assets/3030010/9f977b2e-7883-40ee-8c2f-8790c478d72b">
