### PR TITLE
fix: Add clear error message for missing 'version' in package.json

### DIFF
--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -59,7 +59,7 @@ export function readPackageManifest(workingDir: string) {
   try {
     const fileData = fs.readFileSync(packagePath, 'utf-8')
     pkg = JSON.parse(fileData) as PackageManifest
-    if (!pkg.name && pkg.version) {
+    if (!pkg.name || !pkg.version) {
       console.log(
         'Package manifest',
         packagePath,


### PR DESCRIPTION
This pull request addresses an issue where the absence of the version key in package.json resulted in an unclear and misleading error message.
Previously, when executing CLI commands such as `yalc publish` or `yalc add` without a version key in package.json, the application threw a generic TypeError related to path operations, which did not directly indicate the actual problem.

### Benefits:
This update ensures that users receive a straightforward and informative error message, making it easier to diagnose configuration issues in their projects. By improving the clarity of error messages, we enhance the user experience and reduce potential confusion during package management tasks.

### Link to Issue:
[Issue 241](https://github.com/wclr/yalc/issues/241)

**CC**: @wclr 